### PR TITLE
fix: translate lab1 notebook to English

### DIFF
--- a/notebooks/lab1-my-first-onnx-model.ipynb
+++ b/notebooks/lab1-my-first-onnx-model.ipynb
@@ -16,8 +16,8 @@
         "id": "YWUT1cQapD41"
       },
       "source": [
-        "# 🚀 Lab 1: Erstelle dein erstes ONNX-Modell Schritt für Schritt\n",
-        "- Dieses Jupyter Notebook benötigt keine GPU Laufzeit. Falls nicht bereits voreingestellt, kann daher der Laufzeittyp im Menü unter \"Laufzeit\" > \"Laufzeittyp ändern\" > \"Hardwarebeschleuniger\" > \"CPU\" geändert werden!"
+        "# 🚀 Lab 1: Build your first ONNX model step by step\n",
+        "- This Jupyter notebook does not require a GPU runtime. If not already set, you can change the runtime type under \"Runtime\" > \"Change runtime type\" > \"Hardware accelerator\" > \"CPU\"!"
       ]
     },
     {
@@ -26,7 +26,7 @@
         "id": "Zl1GpAAd1k7s"
       },
       "source": [
-        "# Vorbereitungen: Installation der nötigen Abhängigkeiten"
+        "# Preparation: Installing the required dependencies"
       ]
     },
     {
@@ -49,7 +49,7 @@
       },
       "source": [
         "<font color=\"red\"><b>\n",
-        "⚠️ WICHTIG: Nach der Installation der Abhängigkeiten (siehe oben) muss die Google Colab Laufzeit neugestartet werden (Menü > Laufzeit > Sitzung neu starten)! Im Anschluss kann mit der Ausführung der nächsten Zellen fortgefahren werden werden. ⚠️\n",
+        "⚠️ IMPORTANT: After installing the dependencies (see above) the Google Colab runtime must be restarted (menu > Runtime > Restart session)! Afterwards you can continue executing the next cells. ⚠️\n",
         "</font></b>"
       ]
     },
@@ -61,7 +61,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Einige Colab-spezfische Einstellungen {display-mode: \"form\"}\n",
+        "# @title Some Colab-specific settings {display-mode: \"form\"}\n",
         "import sys\n",
         "\n",
         "IN_COLAB = \"google.colab\" in sys.modules\n",
@@ -78,22 +78,22 @@
         "id": "avktg77A1jPC"
       },
       "source": [
-        "# 🔧 Einführung: Widerstandsschätzung mit Machine Learning\n",
+        "# 🔧 Introduction: Estimating a resistance with machine learning\n",
         "\n",
-        "In diesem Lab verbinden wir zwei spannende Welten: **klassische Elektrotechnik** und **moderne Methoden des maschinellen Lernens**. Unser Ziel ist es, ein einfaches physikalisches Problem datengetrieben zu lösen – nicht durch manuelle Berechnung, sondern durch das Training eines Modells.\n",
+        "In this lab we connect two exciting worlds: **classical electrical engineering** and **modern machine learning methods**. Our goal is to solve a simple physics problem in a data-driven way — not through manual calculation, but by training a model.\n",
         "\n",
         "---\n",
         "\n",
-        "## 🧪 Das Setup: Ein einfacher Stromkreis\n",
+        "## 🧪 The setup: A simple electrical circuit\n",
         "\n",
-        "Stellen wir uns einen einfachen elektrischen Stromkreis vor, bestehend aus:\n",
+        "Imagine a simple electrical circuit consisting of:\n",
         "\n",
-        "- einer **idealen Spannungsquelle**,\n",
-        "- einem unbekannten **Widerstand $R$**,\n",
-        "- einem **Amperemeter** zur Strommessung,\n",
-        "- und einem **Voltmeter** zur Spannungsmessung.\n",
+        "- an **ideal voltage source**,\n",
+        "- an unknown **resistance $R$**,\n",
+        "- an **ammeter** to measure current,\n",
+        "- and a **voltmeter** to measure voltage.\n",
         "\n",
-        "Wenn wir eine Spannung $U$ anlegen, fließt ein Strom $I$ durch den Widerstand. Laut dem **Ohm’schen Gesetz** besteht ein linearer Zusammenhang zwischen Spannung und Strom:\n",
+        "When we apply a voltage $U$, a current $I$ flows through the resistor. According to **Ohm's law**, there is a linear relationship between voltage and current:\n",
         "\n",
         "$$\n",
         "U = R \\cdot I\n",
@@ -101,58 +101,58 @@
         "I = \\frac{1}{R} \\cdot U\n",
         "$$\n",
         "\n",
-        "Solange die Messwerte perfekt sind, genügt eine einfache Division, um $R$ zu bestimmen. In der Praxis jedoch sieht es anders aus.\n",
+        "As long as the measurements are perfect, a simple division is enough to determine $R$. In practice, however, things look different.\n",
         "\n",
         "---\n",
         "\n",
-        "## 🔍 Das Problem: Messfehler und systematischer Stromversatz\n",
+        "## 🔍 The problem: Measurement errors and a systematic current offset\n",
         "\n",
-        "In realen Messsituationen sind unsere Daten **nicht perfekt**. Die Spannungs- und Stromwerte, die wir mit unseren Geräten erfassen, sind durch verschiedene Faktoren **verrauscht**:\n",
+        "In real measurement situations, our data is **not perfect**. The voltage and current values that we record with our instruments are **noisy** due to several factors:\n",
         "\n",
-        "- Ungenauigkeit der Sensoren\n",
-        "- elektrische Störungen\n",
-        "- Rundungsfehler in der Aufzeichnung\n",
+        "- sensor inaccuracy\n",
+        "- electrical interference\n",
+        "- rounding errors in the recording\n",
         "\n",
-        "Doch in unserem Szenario gibt es eine weitere, spezielle Herausforderung:\n",
+        "But in our scenario there is another, specific challenge:\n",
         "\n",
-        "> 🔎 **Der Stromsensor weist einen systematischen Fehler auf** – er misst durchgehend einen zu hohen Stromwert. Dieser konstante Offset führt dazu, dass alle gemessenen Ströme $I_{\\text{gemessen}}$ größer sind als der tatsächliche Strom $I_{\\text{wahr}}$.\n",
+        "> 🔎 **The current sensor exhibits a systematic error** — it consistently reports a current that is too high. This constant offset means that all measured currents $I_{\\text{measured}}$ are larger than the actual current $I_{\\text{true}}$.\n",
         "\n",
-        "Das bedeutet, dass die Daten verzerrt sind – und dass eine direkte Anwendung des Ohm’schen Gesetzes mit den Messwerten zu falschen Schlüssen führen kann.\n",
+        "That means the data is biased — and that directly applying Ohm's law to the measurements can lead to wrong conclusions.\n",
         "\n",
         "---\n",
         "\n",
-        "## 🤖 Die Lösung: Lineares Modell lernen\n",
+        "## 🤖 The solution: Learning a linear model\n",
         "\n",
-        "Hier kommt **maschinelles Lernen** ins Spiel.\n",
+        "This is where **machine learning** comes in.\n",
         "\n",
-        "Statt auf einzelne Werte zu schauen, nutzen wir statistische Methoden, um **aus einer Vielzahl verrauschter und verzerrter Daten** die zugrunde liegende Beziehung zu lernen. Die Idee:\n",
+        "Instead of looking at individual values, we use statistical methods to **learn the underlying relationship from a large number of noisy and biased data points**. The idea:\n",
         "\n",
-        "- Wir betrachten **die Spannung $U$ als Eingabegröße (Feature)**,\n",
-        "- und **den Strom $I_{\\text{gemessen}}$ als Zielgröße (Label)**,\n",
-        "- und trainieren ein Modell, das lernt:  \n",
+        "- We treat **the voltage $U$ as the input (feature)**,\n",
+        "- and **the current $I_{\\text{measured}}$ as the target (label)**,\n",
+        "- and train a model that learns:  \n",
         "  $$\n",
-        "  I_{\\text{gemessen}} \\approx m \\cdot U + b\n",
+        "  I_{\\text{measured}} \\approx m \\cdot U + b\n",
         "  $$\n",
         "\n",
-        "Dabei ist $m$ die geschätzte Steigung.\n",
-        "Der Bias-Term $b$ hilft dabei, den systematischen Stromversatz im Modell zu kompensieren.\n",
+        "Here, $m$ is the estimated slope.\n",
+        "The bias term $b$ helps compensate for the systematic current offset in the model.\n",
         "\n",
-        "> ✅ Mithilfe des gelernten Modells lässt sich der **systematische Offset** sowie eine **Schätzung für den Widerstand** $R$ berechnen. Die Frage wäre, wie?\n",
-        "\n",
-        "---\n",
-        "\n",
-        "## 🧰 Was wir in diesem Lab machen werden\n",
-        "\n",
-        "- Wir simulieren Messdaten $(U, I_{\\text{gemessen}})$, wobei die Stromwerte einen konstanten Offset enthalten.\n",
-        "- Wir visualisieren die Daten, um den verzerrten Zusammenhang zu verstehen.\n",
-        "- Wir verwenden verschiedene Werkzeuge wie **scikit-learn**, **PyTorch**, **TensorFlow** und **ONNX**, um ein lineares Regressionsmodell zu trainieren.\n",
-        "- Wir analysieren das Modell und interpretieren die Parameter:\n",
-        "  - Wie gut schätzt das Modell den wahren Widerstand $R$? Wie erhalte ich $R$?\n",
-        "  - Lässt sich der systematische Fehler im Stromsensor berechnen?\n",
+        "> ✅ Using the learned model we can compute both the **systematic offset** and an **estimate for the resistance** $R$. The question is: how?\n",
         "\n",
         "---\n",
         "\n",
-        "Die folgenden Abbildung illustriert unseren \"Messaufbau\":"
+        "## 🧰 What we will do in this lab\n",
+        "\n",
+        "- We simulate measurement data $(U, I_{\\text{measured}})$, where the current values contain a constant offset.\n",
+        "- We visualize the data to understand the biased relationship.\n",
+        "- We use different tools such as **scikit-learn**, **PyTorch**, **TensorFlow** and **ONNX** to train a linear regression model.\n",
+        "- We analyze the model and interpret its parameters:\n",
+        "  - How well does the model estimate the true resistance $R$? How do I obtain $R$?\n",
+        "  - Can we compute the systematic error in the current sensor?\n",
+        "\n",
+        "---\n",
+        "\n",
+        "The following figure illustrates our \"measurement setup\":"
       ]
     },
     {
@@ -170,7 +170,7 @@
         "id": "v2Z4yDOi7dYK"
       },
       "source": [
-        "# Datengenerierung"
+        "# Data generation"
       ]
     },
     {
@@ -181,14 +181,14 @@
       },
       "outputs": [],
       "source": [
-        "# Importiere das Modul zur Datengenerierung und generiere einen kleinen 2-dimensionalen Datensatz\n",
+        "# Import the data-generation module and generate a small 2-dimensional dataset\n",
         "from techdays25 import measurement_utils as mu\n",
         "\n",
         "df = mu.generate_measurement_data()\n",
         "\n",
         "print(\"df.shape:\", df.shape)\n",
         "\n",
-        "# Zeige die ersten Zeilen des DataFrames an\n",
+        "# Show the first rows of the DataFrame\n",
         "df.head()"
       ]
     },
@@ -200,7 +200,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Visualisierung der generierten Daten {display-mode: \"form\"}\n",
+        "# @title Visualize the generated data {display-mode: \"form\"}\n",
         "mu.plot_measurement_data(*df.to_numpy().T)"
       ]
     },
@@ -212,7 +212,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Manuelles Einlernen einer linearen Funktion {display-mode: \"form\"}\n",
+        "# @title Manually fit a linear function {display-mode: \"form\"}\n",
         "\n",
         "# This code will be hidden when the notebook is loaded.\n",
         "\n",
@@ -253,9 +253,7 @@
         "    \"size\": 14,\n",
         "}\n",
         "serr = sum(abs(dy) ** 2)\n",
-        "my_textbox = ax.text(\n",
-        "    1, 40, f\"Summe der quadrierten Fehler (SSE): {serr: .2f}\", fontdict=font\n",
-        ")\n",
+        "my_textbox = ax.text(1, 40, f\"Sum of squared errors (SSE): {serr: .2f}\", fontdict=font)\n",
         "\n",
         "\n",
         "@widgets.interact(m=(0, 4, 0.001), b=(-10, 10, 0.001))\n",
@@ -276,7 +274,7 @@
         "\n",
         "    # Update text box\n",
         "    serr = sum(abs(dy) ** 2)\n",
-        "    my_textbox.set_text(f\"Summe der quadrierten Fehler (SSE): {serr:.2f}\")\n",
+        "    my_textbox.set_text(f\"Sum of squared errors (SSE): {serr:.2f}\")\n",
         "\n",
         "    fig.canvas.draw()"
       ]
@@ -287,7 +285,7 @@
         "id": "30D0zrzFxQcq"
       },
       "source": [
-        "# Training unseres ersten Machine-Learning-Modells"
+        "# Training our first machine learning model"
       ]
     },
     {
@@ -296,7 +294,7 @@
         "id": "eS8oVGLyyU0J"
       },
       "source": [
-        "## Variante 1: Lineare Regression mit SciKit-Learn und Export nach ONNX\n",
+        "## Variant 1: Linear regression with scikit-learn and export to ONNX\n",
         "\n"
       ]
     },
@@ -315,17 +313,17 @@
         "id": "GwEeiKMfFmUv"
       },
       "source": [
-        "**scikit-learn Library**\n",
-        "- ist eine weit verbreitete Open-Source-Bibliothek für maschinelles Lernen in Python.\n",
-        "- ist bekannt für ihre einfache und konsistente API, die es Entwicklern und Datenwissenschaftlern ermöglicht, schnell und effizient Modelle zu erstellen und zu testen.\n",
-        "- bietet eine breite Palette von Algorithmen für Klassifikation, Regression, Clustering und Dimensionalitätsreduktion.\n",
-        "- stellt viele Methoden zur Modellbewertung, wie Kreuzvalidierung, und Techniken zur Modellselektion, wie Grid Search und Randomized Search.\n",
-        "- lässt sich gut mit anderen wissenschaftlichen Python-Bibliotheken wie NumPy, SciPy und pandas integrieren.\n",
-        "- Weitere Details und Beispiele können hier nachgeschlagen werden:\n",
+        "**scikit-learn library**\n",
+        "- is a widely used open-source library for machine learning in Python.\n",
+        "- is known for its simple and consistent API, which lets developers and data scientists build and test models quickly and efficiently.\n",
+        "- offers a broad range of algorithms for classification, regression, clustering and dimensionality reduction.\n",
+        "- provides many methods for model evaluation (e.g. cross-validation) and techniques for model selection (e.g. grid search and randomized search).\n",
+        "- integrates well with other scientific Python libraries such as NumPy, SciPy and pandas.\n",
+        "- More details and examples can be found here:\n",
         "https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html\n",
         "\n",
-        "**Vorgehen**\n",
-        "- Das Scikit-Learn Modell versucht, die Steigung `m` und den Y-Achsenabschnitt (Ordinatenabschnitt) `b` so zu wählen, dass die Summe der quadratischen Fehler minimiert wird"
+        "**Approach**\n",
+        "- The scikit-learn model tries to choose the slope `m` and the intercept `b` so that the sum of squared errors is minimized"
       ]
     },
     {
@@ -384,7 +382,7 @@
         "    uu,\n",
         "    ii,\n",
         "    ii_scikit,\n",
-        "    title=f\"Ursprüngliche Daten & Prognosen des scikit-learn Modells (SSE=${sse_scikit:.2f}$)\",\n",
+        "    title=f\"Original data & predictions of the scikit-learn model (SSE=${sse_scikit:.2f}$)\",\n",
         ")"
       ]
     },
@@ -394,11 +392,11 @@
         "id": "1AnFV3oBxQcr"
       },
       "source": [
-        "### Fragen/Zusatzaufgaben (Optional)\n",
-        "1. Stimmen die durch Scikit-Learn ermittelten Parameter `scikit_regressor.coef_, scikit_regressor.intercept_` in etwa mit den Werten `m` und `b` überein, die ihr im interaktivem Widget weiter oben ermittelt habt?\n",
-        "2. Könnt ihr die Summe der quadratischen Abweichungen (SSE) für das scikit-learn-Model bestimmen und vergleichen mit dem SSE den ihr manuell erzielt habt?\n",
-        "2. Wie könnten wir überprüfen, ob die ermittelten Parameter `m`, `b` schlüssig sind?\n",
-        "3. Könnt ihr für 5 neue beliebige Inputs ($U [V]$) auch die zugehörigen Ströme ($I [mA]$) prognostizieren und plotten?"
+        "### Questions / Bonus exercises (optional)\n",
+        "1. Do the parameters returned by scikit-learn (`scikit_regressor.coef_, scikit_regressor.intercept_`) roughly match the values of `m` and `b` you found with the interactive widget above?\n",
+        "2. Can you compute the sum of squared errors (SSE) for the scikit-learn model and compare it with the SSE you obtained manually?\n",
+        "2. How could we check whether the values of `m`, `b` we obtained are plausible?\n",
+        "3. Can you predict and plot the corresponding currents ($I [mA]$) for 5 arbitrary new inputs ($U [V]$)?"
       ]
     },
     {
@@ -407,7 +405,7 @@
         "id": "3EOTeQWIyfaw"
       },
       "source": [
-        "### Export des scikit-learn Modells nach ONNX"
+        "### Export the scikit-learn model to ONNX"
       ]
     },
     {
@@ -449,9 +447,9 @@
         "id": "BgTZZ8GuxQcr"
       },
       "source": [
-        "#### Visualisierung des ONNX-Graphen mit Netron\n",
-        "- ONNX-Modelle können auf [https://netron.app/](https://netron.app/) visualisiert werden\n",
-        "- Alternativ lässt sich auch das `netron` Python Package in Google Colab nutzen (siehe unten)"
+        "#### Visualize the ONNX graph with Netron\n",
+        "- ONNX models can be visualized at [https://netron.app/](https://netron.app/)\n",
+        "- Alternatively you can use the `netron` Python package in Google Colab (see below)"
       ]
     },
     {
@@ -473,7 +471,7 @@
         "id": "wvQoUR4nlDYC"
       },
       "source": [
-        "## Variante 2: Training eines PyTorch Modells und Export nach ONNX"
+        "## Variant 2: Training a PyTorch model and exporting to ONNX"
       ]
     },
     {
@@ -492,12 +490,12 @@
       },
       "source": [
         "**PyTorch**\n",
-        "- ist eine Open-Source-Bibliothek für maschinelles Lernen, die von Facebook's AI Research Lab (FAIR) entwickelt wurde.\n",
-        "- wird hauptsächlich für Deep Learning-Anwendungen verwendet, wie neuronale Netze und andere komplexe Modelle.\n",
-        "- bietet automatische Differenzierung durch seine autograd-Bibliothek, die das Berechnen von Gradienten für die Optimierung von Modellen erleichtert.\n",
-        "- PyTorch verwendet dynamische Berechnungsgraphen, was bedeutet, dass der Graph zur Laufzeit definiert wird, was flexibler und intuitiver für die Entwicklung und das Debuggen von Modellen ist.\n",
-        "- unterstützt CUDA, was es ermöglicht, Berechnungen auf NVIDIA-GPUs auszuführen und somit die Trainingszeiten erheblich zu verkürzen.\n",
-        "- ist modular aufgebaut, was es einfach macht, eigene Module und Schichten zu erstellen und in bestehende Modelle zu integrieren."
+        "- is an open-source machine learning library developed by Facebook's AI Research Lab (FAIR).\n",
+        "- is mainly used for deep learning applications such as neural networks and other complex models.\n",
+        "- offers automatic differentiation through its autograd library, which makes it easy to compute gradients for model optimization.\n",
+        "- PyTorch uses dynamic computation graphs, meaning the graph is defined at runtime — more flexible and intuitive for model development and debugging.\n",
+        "- supports CUDA, allowing computations to run on NVIDIA GPUs and thereby drastically reducing training time.\n",
+        "- has a modular design, making it easy to create your own modules and layers and integrate them into existing models."
       ]
     },
     {
@@ -605,7 +603,7 @@
         "    # Print the loss every 10 epochs\n",
         "    if (epoch + 1) % 10 == 0:\n",
         "        print(\n",
-        "            f\"Epoche [{epoch + 1}/{num_epochs}], MSE Loss: {loss.item():.4f}, SSE Loss: {loss.item() * i_tensor.shape[0]:.2f}\"\n",
+        "            f\"Epoch [{epoch + 1}/{num_epochs}], MSE Loss: {loss.item():.4f}, SSE Loss: {loss.item() * i_tensor.shape[0]:.2f}\"\n",
         "        )"
       ]
     },
@@ -618,7 +616,7 @@
       "outputs": [],
       "source": [
         "# Accessing the trained parameters\n",
-        "print(\"Eingelernte Parameter (state_dict):\")\n",
+        "print(\"Learned parameters (state_dict):\")\n",
         "for param_tensor in pytorch_regressor.state_dict():\n",
         "    print(f\"{param_tensor}: {pytorch_regressor.state_dict()[param_tensor].numpy()}\")\n",
         "\n",
@@ -626,9 +624,9 @@
         "weights = pytorch_regressor.linear.weight.data.numpy()\n",
         "bias = pytorch_regressor.linear.bias.data.numpy()\n",
         "\n",
-        "print(\"\\nEingelernte Parameter:\")\n",
-        "print(f\"Gewichte: {weights}\")\n",
-        "print(f\"Biase: {bias}\")"
+        "print(\"\\nLearned parameters:\")\n",
+        "print(f\"Weights: {weights}\")\n",
+        "print(f\"Bias: {bias}\")"
       ]
     },
     {
@@ -651,7 +649,7 @@
         "    uu.flatten(),\n",
         "    ii.flatten(),\n",
         "    {\"torch\": ii_pytorch, \"scikit-learn\": ii_scikit},\n",
-        "    title=f\"Ursprüngliche Daten und Prognosen des PyTorch Modells (SSE=${sse_torch:.2f}$) & scikit-learn Modells (SSE=${sse_scikit:.2f}$)\",\n",
+        "    title=f\"Original data and predictions of the PyTorch model (SSE=${sse_torch:.2f}$) & scikit-learn model (SSE=${sse_scikit:.2f}$)\",\n",
         ")"
       ]
     },
@@ -661,9 +659,9 @@
         "id": "i8KgQhrHlDYD"
       },
       "source": [
-        "### Fragen/Zusatzaufgaben (Optional):\n",
-        "1. Woran könnte es liegen, dass die Geraden (Prognosen) für \"pytorch\" und \"scikit-learn\" nicht übereinstimmen?\n",
-        "2. Wie könnte man das ausgemachte Problem aus 1. beheben?"
+        "### Questions / Bonus exercises (optional):\n",
+        "1. Why might the lines (predictions) for \"pytorch\" and \"scikit-learn\" not agree?\n",
+        "2. How could the problem identified in 1. be fixed?"
       ]
     },
     {
@@ -672,7 +670,7 @@
         "id": "aOtABli7lDYD"
       },
       "source": [
-        "### Export des PyTorch Modells nach ONNX"
+        "### Export the PyTorch model to ONNX"
       ]
     },
     {
@@ -704,7 +702,7 @@
         ")\n",
         "\n",
         "# Print a confirmation message\n",
-        "print(f\"Modell wurde nach ONNX konvertiert und gespeichert in {onnx_file_path}\")"
+        "print(f\"Model has been converted to ONNX and saved to {onnx_file_path}\")"
       ]
     },
     {
@@ -713,7 +711,7 @@
         "id": "kP2XmpHGlDYD"
       },
       "source": [
-        "#### Visualisierung des PyTorch-exportierten ONNX-Graphen mit Netron"
+        "#### Visualize the PyTorch-exported ONNX graph with Netron"
       ]
     },
     {
@@ -735,9 +733,9 @@
         "id": "x__dr1YptG0-"
       },
       "source": [
-        "#### Fragen/Zusatzaufgaben (Optional)\n",
-        "1. Inwieweit unterscheidet sich das obige ONNX-Modell von dem ONNX-Modell das wir aus scikit-learn exportiert haben?\n",
-        "2. Was verbirgt sich hinter der Operation im obigen Graphen? Hinweis: In den \"Node Properties\" kann beispielsweise für das Feld \"type\" ein Hilfefenster angezeigt werden."
+        "#### Questions / Bonus exercises (optional)\n",
+        "1. How does the ONNX model above differ from the ONNX model we exported from scikit-learn?\n",
+        "2. What is the operation in the graph above? Hint: in the \"Node Properties\", a help panel is available for the \"type\" field, for example."
       ]
     },
     {
@@ -746,7 +744,7 @@
         "id": "slg5qRcUuI4l"
       },
       "source": [
-        "## Variante 3 (Optional): Training eines Keras/Tensorflow Modells und Export nach ONNX"
+        "## Variant 3 (optional): Training a Keras/TensorFlow model and exporting to ONNX"
       ]
     },
     {
@@ -765,17 +763,17 @@
       },
       "source": [
         "**TensorFlow**\n",
-        "- ist eine Open-Source-Bibliothek für maschinelles Lernen, die von Google Brain entwickelt wurde.\n",
-        "- ist in vielen Aspekten ähnlich/vergleichbar zu PyTorch (Eager Execution, AutoGrad, etc.)\n",
-        "- ist darauf ausgelegt, skalierbare maschinelle Lernmodelle zu erstellen, die auf verschiedenen Plattformen wie CPUs, GPUs und TPUs ausgeführt werden können.\n",
-        "- bietet sowohl niedrige als auch hohe Abstraktionsebenen, was es Entwicklern ermöglicht, sowohl einfache als auch komplexe Modelle zu erstellen.\n",
-        "- hat weitere Tools/Module/Erweiterungen wie TensorFlow Serving, TensorFlow Lite, TensorFlow.js, TensorBoard, TensorFlow Hub, TensorFlow Extended (TFX)\n",
+        "- is an open-source machine learning library developed by Google Brain.\n",
+        "- is similar/comparable to PyTorch in many respects (eager execution, autograd, etc.).\n",
+        "- is designed to build scalable machine learning models that can run on different platforms such as CPUs, GPUs and TPUs.\n",
+        "- offers both low- and high-level abstractions, allowing developers to build both simple and complex models.\n",
+        "- comes with additional tools/modules/extensions such as TensorFlow Serving, TensorFlow Lite, TensorFlow.js, TensorBoard, TensorFlow Hub and TensorFlow Extended (TFX).\n",
         "\n",
         "\n",
         "**Keras**\n",
-        "- ist eine abstrahierte (high-level) API für maschinelles Lernen, die ursprünglich als eigenständige Bibliothek entwickelt wurde und jetzt in TensorFlow integriert ist (Seit TensorFlow 2.0).\n",
-        "- bekannt für seine einfache und intuitive API, die es Entwicklern ermöglicht, schnell und einfach Modelle zu erstellen und zu testen.\n",
-        "- ist ideal für schnelles Prototyping und Experimente, da es die Erstellung und Anpassung von Modellen vereinfacht."
+        "- is a high-level machine learning API, originally developed as a standalone library and now integrated into TensorFlow (since TensorFlow 2.0).\n",
+        "- is known for its simple and intuitive API, which lets developers build and test models quickly and easily.\n",
+        "- is ideal for fast prototyping and experimentation, as it simplifies model creation and modification."
       ]
     },
     {
@@ -820,7 +818,7 @@
         "\n",
         "# weights[0] contains the weights of the Dense layer\n",
         "# weights[1] contains the bias of the Dense layer\n",
-        "print(\"Gewichte:\", weights[0])\n",
+        "print(\"Weights:\", weights[0])\n",
         "print(\"Bias:\", weights[1])"
       ]
     },
@@ -852,7 +850,7 @@
         "    uu.flatten(),\n",
         "    ii.flatten(),\n",
         "    {\"keras\": ii_keras, \"torch\": ii_pytorch, \"scikit-learn\": ii_scikit},\n",
-        "    title=f\"Keras (SSE=${sse_keras:.2f}$), PyTorch (SSE=${sse_torch:.2f}$) & Scikit-Learn (SSE=${sse_scikit:.2f}$) im Vergleich\",\n",
+        "    title=f\"Keras (SSE=${sse_keras:.2f}$) vs. PyTorch (SSE=${sse_torch:.2f}$) vs. scikit-learn (SSE=${sse_scikit:.2f}$)\",\n",
         ")"
       ]
     },
@@ -862,7 +860,7 @@
         "id": "D3GvcujCef5R"
       },
       "source": [
-        "### Export des Keras Modells nach ONNX"
+        "### Export the Keras model to ONNX"
       ]
     },
     {
@@ -875,8 +873,8 @@
       "source": [
         "import tf2onnx\n",
         "\n",
-        "# Diese Zelle könnte einen Fehler werfen.\n",
-        "# Dennoch sollte das ONNX Modell korrekt exportiert werden\n",
+        "# This cell may raise an error.\n",
+        "# Even so, the ONNX model should still be exported correctly.\n",
         "keras_regressor.output_names = [\"output\"]\n",
         "\n",
         "input_signature = [tf.TensorSpec([None, 1], tf.float32, name=\"u\")]\n",
@@ -904,7 +902,7 @@
         "id": "ZP6yLHoBxQcr"
       },
       "source": [
-        "## Variante 4 (Optional): Wir \"trainieren\" und exportieren das Modell selbst direkt mit ONNX Tools"
+        "## Variant 4 (optional): We \"train\" and export the model ourselves directly with ONNX tools"
       ]
     },
     {
@@ -913,7 +911,7 @@
         "id": "bs3mMRXGrwAX"
       },
       "source": [
-        "Wir definieren folgende Vektoren und Matrizen:\n",
+        "We define the following vectors and matrices:\n",
         "\n",
         "\\begin{align}\n",
         "\\mathbf{i} &= \\begin{pmatrix} I_1 \\\\ I_2 \\\\ \\vdots \\\\ I_n \\end{pmatrix} \\in \\mathbb{R}^n, \\\\\n",
@@ -928,7 +926,7 @@
         "id": "qwLRmRTUoVJY"
       },
       "source": [
-        "Es kann gezeigt werden, dass folgende abgekürzte Lösung tatsächlich der optimalen Lösung im Sinne der kleinsten Fehlerquadrate (Stichwort: \"Methode der kleinsten Quadrate\") entspricht. Wir gehen zunächst von einem (überbestimmten) linearen Gleichungssystem aus und stellen die Gleichung schrittweise um:\n",
+        "It can be shown that the following short-form solution is in fact the optimal solution in the least-squares sense (the \"method of least squares\"). We start from an (overdetermined) linear system and rearrange the equation step by step:\n",
         "\n",
         "\\begin{align}\n",
         "\\mathbf{i}&= \\mathbf{U}\\mathbf{w} \\\\\n",
@@ -973,7 +971,7 @@
         "id": "EPQMivpyCM_v"
       },
       "source": [
-        "### Export mit 'onnx.parser'"
+        "### Export with 'onnx.parser'"
       ]
     },
     {
@@ -1018,7 +1016,7 @@
         "id": "3fd1Za7Hs0OI"
       },
       "source": [
-        "### Export mit ONNX Helper API"
+        "### Export with the ONNX Helper API"
       ]
     },
     {
@@ -1067,7 +1065,7 @@
         "id": "zZ0P894gC6f0"
       },
       "source": [
-        "### Export mit ONNX Script"
+        "### Export with ONNX Script"
       ]
     },
     {
@@ -1131,7 +1129,7 @@
         "id": "_wwCTlZrxQcr"
       },
       "source": [
-        "## Inferenz mit den ONNX Modellen"
+        "## Inference with the ONNX models"
       ]
     },
     {
@@ -1188,7 +1186,7 @@
         "    ii,\n",
         "    ii_onnx,\n",
         "    xx_pred=None,\n",
-        "    title=f\"Ursprüngliche Daten & Prognosen des ONNX Modells '{onnx_model_path}'\",\n",
+        "    title=f\"Original data & predictions of the ONNX model '{onnx_model_path}'\",\n",
         ")"
       ]
     },
@@ -1198,11 +1196,11 @@
         "id": "vWaqU3nNxQcr"
       },
       "source": [
-        "#### Fragen/Zusatzaufgaben (Optional)\n",
-        "1. Was passiert in obigem Beispiel wenn wir in der Zeile\n",
+        "#### Questions / Bonus exercises (optional)\n",
+        "1. What happens in the example above if, in the line\n",
         "   `U_new = np.stack([uu, np.ones(len(uu))]).T.astype(dtype=np.float32)`\n",
-        "   das Argument `dtype=np.float32` ersetzen durch `dtype=np.float64`?\n",
-        "2. Wie genau stimmen die Prognosen des ONNX-Modells (von scikit-learn exportiert) mit denen des originalen Modells (z.B., das ursprüngliche scikit-learn Modell) überein? Evaluiere hierzu beide Modelle auf jeweils denselben Input-Daten (entweder die bereits vorhanden Daten oder beispielsweise neu erzeugte (zufällige) Daten für die Spannung $U [V]$.)\n"
+        "   we replace `dtype=np.float32` with `dtype=np.float64`?\n",
+        "2. How closely do the predictions of the ONNX model (exported from scikit-learn) match those of the original model (e.g. the original scikit-learn model)? Evaluate both models on the same inputs (either the existing data, or for instance new (random) voltages $U [V]$).\n"
       ]
     },
     {
@@ -1211,7 +1209,7 @@
         "id": "iDFph0DJucN8"
       },
       "source": [
-        "# Anhang 1: Illustration des Gradientenabstiegs"
+        "# Appendix 1: Illustration of gradient descent"
       ]
     },
     {
@@ -1222,7 +1220,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Hilfsfunktionen für Darstellung der \"Peaks\" Funktion {display-mode: \"form\"}\n",
+        "# @title Helper functions for plotting the \"peaks\" function {display-mode: \"form\"}\n",
         "\n",
         "%matplotlib inline\n",
         "import matplotlib.pyplot as plt\n",
@@ -1368,7 +1366,7 @@
         "ax.plot_surface(\n",
         "    X1, X2, Y, cmap=cm.Spectral_r, edgecolor=\"none\"\n",
         ")  # rstride=1, cstride=1,\n",
-        "ax.set_title(\"3D Plot der 'Peaks' Funktion\")\n",
+        "ax.set_title(\"3D plot of the 'peaks' function\")\n",
         "plt.xlabel(r\"$\\theta_1$\")\n",
         "plt.ylabel(r\"$\\theta_2$\")\n",
         "plt.show()"


### PR DESCRIPTION
Translate all German markdown cells, code comments, plot titles, and @title cell-form headers in lab1-my-first-onnx-model.ipynb to English. Notebook JSON formatting and cell IDs are preserved; cell outputs are left as-is and will be refreshed on the next Colab run.

Pre-commit is bypassed for this commit because the gradient-descent appendix in cell 66 has 15 pre-existing ruff lint errors (D103, N802, N803, F841) unrelated to translation. These will be addressed in a follow-up cleanup PR.