### PR TITLE
fix: translate lab2 notebook to English

### DIFF
--- a/notebooks/lab2-model-quantization.ipynb
+++ b/notebooks/lab2-model-quantization.ipynb
@@ -16,8 +16,8 @@
         "id": "EKWrVTJSVVy4"
       },
       "source": [
-        "# 🚀 Lab 2: Effiziente Quantisierung tiefer neuronaler Netze\n",
-        "- Dieses Jupyter Notebook **benötigt eine GPU Laufzeit**. Falls nicht bereits voreingestellt, kann daher der Laufzeittyp im Menü unter \"Laufzeit\" > \"Laufzeittyp ändern\" > \"Hardwarebeschleuniger\" > **\"T4 GPU\"** geändert werden!"
+        "# 🚀 Lab 2: Efficient quantization of deep neural networks\n",
+        "- This Jupyter notebook **requires a GPU runtime**. If not already set, you can change the runtime type under \"Runtime\" > \"Change runtime type\" > \"Hardware accelerator\" > **\"T4 GPU\"**!"
       ]
     },
     {
@@ -26,7 +26,7 @@
         "id": "HHjiyBN9VVy4"
       },
       "source": [
-        "# Vorbereitungen: Installation der nötigen Abhängigkeiten"
+        "# Preparation: Installing the required dependencies"
       ]
     },
     {
@@ -49,7 +49,7 @@
       },
       "source": [
         "<font color=\"red\"><b>\n",
-        "⚠️ WICHTIG: Nach der Installation der Abhängigkeiten (siehe oben) muss die Google Colab Laufzeit neugestartet werden (Menü > Laufzeit > Sitzung neu starten)! Im Anschluss kann mit der Ausführung der nächsten Zellen fortgefahren werden werden. ⚠️\n",
+        "⚠️ IMPORTANT: After installing the dependencies (see above) the Google Colab runtime must be restarted (menu > Runtime > Restart session)! Afterwards you can continue executing the next cells. ⚠️\n",
         "</font></b>"
       ]
     },
@@ -73,7 +73,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Colab-spezifische Konfigurationen {display-mode: \"form\"}\n",
+        "# @title Colab-specific configuration {display-mode: \"form\"}\n",
         "import sys\n",
         "\n",
         "IN_COLAB = \"google.colab\" in sys.modules\n",
@@ -90,15 +90,15 @@
         "id": "NPuTmcJKVVy5"
       },
       "source": [
-        "# 📘 Einleitung und Gliederung\n",
+        "# 📘 Introduction and outline\n",
         "\n",
-        "Dieses Jupyter Notebook ist in 4 Teile gegliedert. Es empfiehlt sich, die einzelnen Teile von vorne beginnend, nacheinander durchzuarbeiten.\n",
+        "This Jupyter notebook is divided into 4 parts. We recommend working through them in order, starting from the first.\n",
         "\n",
-        "- 📖 Teil 1: Darstellung numerischer Datentypen\n",
-        "  - In diesem Teil wiederholen wir verschiedene Darstellungen von numerischen Datentypen und lernen in einem interaktivem Modul die Unterschiede zwischen diesen kennen.\n",
-        "- 🔢 Teil 2 (Optional): Quantisierung eines linearen Regressionsmodells (aus Lab 1)\n",
-        "- 🕸 Teil 3 (Optional): Gotchas bei der Modellquantisierung am Beispiel eines einfachen Modells\n",
-        "- 📞 Teil 4: Quantisierung eines DTMF Klassifikationsmodells"
+        "- 📖 Part 1: Representation of numeric data types\n",
+        "  - In this part we revisit different representations of numeric data types and use an interactive module to explore the differences between them.\n",
+        "- 🔢 Part 2 (optional): Quantizing a linear regression model (from Lab 1)\n",
+        "- 🕸 Part 3 (optional): Gotchas in model quantization, illustrated with a simple example\n",
+        "- 📞 Part 4: Quantizing a DTMF classification model"
       ]
     },
     {
@@ -107,7 +107,7 @@
         "id": "v-emxsEEVVy5"
       },
       "source": [
-        "# 📖 Teil 1: Darstellung numerischer Datentypen"
+        "# 📖 Part 1: Representation of numeric data types"
       ]
     },
     {
@@ -116,7 +116,7 @@
         "id": "e0MW1AnSVVy5"
       },
       "source": [
-        "### Ganzahldarstellungen/Zweierkomplementdarstellung"
+        "### Integer representation / two's-complement representation"
       ]
     },
     {
@@ -127,7 +127,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Darstellung von 8-Bit Integer Zahlen {display-mode: \"form\"}\n",
+        "# @title Representation of 8-bit integer numbers {display-mode: \"form\"}\n",
         "\n",
         "import ipywidgets as widgets\n",
         "from IPython.display import HTML, display\n",
@@ -194,7 +194,7 @@
         "        display(\n",
         "            HTML(f\"\"\"\n",
         "        <h3>\n",
-        "            Binärdarstellung: <code>\n",
+        "            Binary representation: <code>\n",
         "                <span style=\"color: red;\">{bit_string[0]}</span>\n",
         "                <span style=\"color: green;\">{bit_string[1:]}</span>\n",
         "            </code><br>\n",
@@ -228,15 +228,15 @@
         "id": "TDlSxZqOVVy6"
       },
       "source": [
-        "#### Übungsfragen (Optional):\n",
+        "#### Practice questions (optional):\n",
         "\n",
-        "- Was ist die größtmögliche bzw. kleinstmögliche Zahl die mit 8 Bit dargestellt werden können?\n",
-        "- Signed vs. Unsigned Darstellung: Setze das 8. Bit (höchstwertiges Bit) auf 1 und alle anderen Bits auf 0. Was sind die dezimalen Darstellungen dieser Zahl im signed und unsigned Format?\n",
-        "- Was charakterisiert eine negative Zahl in der Zweierkomplementdarstellung (unsigned integer) im Allgmeinen?\n",
-        "- Wie negiere ich eine Zahl (z.B. 32 -> -32 bzw. -71 -> 71)?\n",
-        "- Angenommen ich habe -33 als 8-bit Zahl vorliegen. Wie würde ich daraus eine 32-bit unsigned Integer Zahl machen?\n",
-        "- Maximale und minimale Werte: Was ist der maximale/minimale Wert, den man mit einer 8-Bit signed/unsigned Zahl darstellen kann?\n",
-        "- Alle Bits gesetzt: Setze alle Bits einer 8-Bit-Zahl auf 1. Was sind die dezimalen Darstellungen dieser Zahl im signed und unsigned Format?"
+        "- What are the largest and smallest numbers that can be represented with 8 bits?\n",
+        "- Signed vs. unsigned representation: set the 8th bit (most significant bit) to 1 and all other bits to 0. What are the decimal values of this number in signed and unsigned formats?\n",
+        "- In general, what characterizes a negative number in two's-complement (unsigned integer) representation?\n",
+        "- How do I negate a number (e.g. 32 -> -32 or -71 -> 71)?\n",
+        "- Suppose I have -33 stored as an 8-bit number. How would I convert it to a 32-bit unsigned integer?\n",
+        "- Maximum and minimum values: what is the largest/smallest value an 8-bit signed/unsigned number can represent?\n",
+        "- All bits set: set every bit of an 8-bit number to 1. What are the decimal values of this number in signed and unsigned formats?"
       ]
     },
     {
@@ -245,7 +245,7 @@
         "id": "4q1kp8MaVVy6"
       },
       "source": [
-        "### Fixkommadarstellungen"
+        "### Fixed-point representations"
       ]
     },
     {
@@ -256,7 +256,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Darstellung von 16-Bit Integer/Festkomma-Zahlen {display-mode: \"form\"}\n",
+        "# @title Representation of 16-bit integer / fixed-point numbers {display-mode: \"form\"}\n",
         "import ipywidgets as widgets\n",
         "from IPython.display import display\n",
         "\n",
@@ -378,7 +378,7 @@
         "        display(\n",
         "            HTML(f\"\"\"\n",
         "        <h3>\n",
-        "            Binärdarstellung: <code>\n",
+        "            Binary representation: <code>\n",
         "                <span style=\"color: red;\">{bit_string[0]}</span>\n",
         "                <span style=\"color: green;\">{bit_string[1:8]}</span>.\n",
         "                <span style=\"color: blue;\">{bit_string[8:]}</span>\n",
@@ -427,10 +427,10 @@
         "id": "bN_oFcfjVVy6"
       },
       "source": [
-        "#### Übungsfragen (Optional):\n",
-        "- Was ist die kleinstmögliche vorzeichenbehaftete Festkommazahl?\n",
-        "- Wie stelle ich -1.25 als Festkommazahl dar?\n",
-        "- Was ist die kleinstmögliche (größtmögliche) Festkommazahl größer (kleiner) als Null?"
+        "#### Practice questions (optional):\n",
+        "- What is the smallest signed fixed-point number?\n",
+        "- How do I represent -1.25 as a fixed-point number?\n",
+        "- What is the smallest (largest) fixed-point number greater (less) than zero?"
       ]
     },
     {
@@ -441,7 +441,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Darstellung von 16-Bit (FP16) Fließkommazahlen nach IEEE 754 {display-mode: \"form\"}\n",
+        "# @title Representation of 16-bit (FP16) IEEE 754 floating-point numbers {display-mode: \"form\"}\n",
         "\n",
         "import struct\n",
         "\n",
@@ -524,16 +524,16 @@
         "        display(\n",
         "            HTML(f\"\"\"\n",
         "        <h3>\n",
-        "            Binärdarstellung: <code>\n",
+        "            Binary representation: <code>\n",
         "                <span style=\"color: red;\">{bit_string[0]}</span>\n",
         "                <span style=\"color: green;\">{bit_string[1:6]}</span>\n",
         "                <span style=\"color: blue;\">{bit_string[6:]}</span>\n",
         "            </code><br>\n",
-        "            Vorzeichen (1 bit): <b>{sign}</b> ({\"-\" if sign else \"+\"})<br>\n",
+        "            Sign (1 bit): <b>{sign}</b> ({\"-\" if sign else \"+\"})<br>\n",
         "            Exponent (5 bits): <b>{\"\".join(str(b) for b in exponent_bits)} (biased: {exponent}, unbiased: {exponent_unbiased})</b><br>\n",
-        "            Mantisse (10 bits): <b>{mantissa_raw}</b><br>\n",
+        "            Mantissa (10 bits): <b>{mantissa_raw}</b><br>\n",
         "            <hr>\n",
-        "            <b>FP16 Dezimaldarstellung: {fp16_value} </b>\n",
+        "            <b>FP16 decimal value: {fp16_value} </b>\n",
         "        </h3>\n",
         "        \"\"\")\n",
         "        )\n",
@@ -573,13 +573,13 @@
         "id": "RBCmHSNeVVy6"
       },
       "source": [
-        "#### Übungsfragen (Optional):\n",
-        "- Wie würde ich 1.0, 0.5 und 7.0 darstellen?\n",
-        "- Was ist die größte/kleinste darstellbare Zahl?\n",
-        "- Gibt es einen Unterschied zwischen +0.0 und -0.0?\n",
-        "- Wie stelle ich `+Inf` bzw. `-Inf` dar?\n",
-        "- Wie stelle ich `NaN` dar?\n",
-        "- Was ergibt der Vergleich `float(\"nan\") != float(\"nan\")`?"
+        "#### Practice questions (optional):\n",
+        "- How would I represent 1.0, 0.5 and 7.0?\n",
+        "- What is the largest/smallest representable number?\n",
+        "- Is there a difference between +0.0 and -0.0?\n",
+        "- How do I represent `+Inf` and `-Inf`?\n",
+        "- How do I represent `NaN`?\n",
+        "- What does the comparison `float(\"nan\") != float(\"nan\")` evaluate to?"
       ]
     },
     {
@@ -588,9 +588,9 @@
         "id": "7youIav3VVy7"
       },
       "source": [
-        "# 🔢 Teil 2 (Optional): Quantisierung eines linearen Regressionsmodells (aus Lab 1)\n",
+        "# 🔢 Part 2 (optional): Quantizing a linear regression model (from Lab 1)\n",
         "\n",
-        "- In diesem Abschnitt werden wir das lineare ONNX-Regressions-Modell, das wir in Lab 1 erzeugt haben, quantisieren und uns die Ergebnisse für verschiedene Quantisierungsstufen (FP32, FP16, INT8) anschauen."
+        "- In this section we quantize the linear ONNX regression model we built in Lab 1 and look at the results for different quantization levels (FP32, FP16, INT8)."
       ]
     },
     {
@@ -649,7 +649,7 @@
         "id": "8Ls-fTM1gqHH"
       },
       "source": [
-        "## Quantisiere ONNX Modell nach FP16"
+        "## Quantize the ONNX model to FP16"
       ]
     },
     {
@@ -691,7 +691,7 @@
         "id": "KbOmu6lDgqHI"
       },
       "source": [
-        "## Quantisiere Modell nach INT8"
+        "## Quantize the model to INT8"
       ]
     },
     {
@@ -877,7 +877,7 @@
         "id": "l_77SjqWgqHI"
       },
       "source": [
-        "## Netron Visualisierung der ONNX Modelle"
+        "## Netron visualization of the ONNX models"
       ]
     },
     {
@@ -900,7 +900,7 @@
         "id": "D6ZYUTq7gqHI"
       },
       "source": [
-        "## Vergleich der quantisierten Modellvarianten mit ursprünglichem Modell"
+        "## Compare the quantized model variants against the original model"
       ]
     },
     {
@@ -967,9 +967,9 @@
         "id": "jzNNq4CUgqHI"
       },
       "source": [
-        "### Fragen (Optional)\n",
-        "- Wie verhalten sich die Modellausgaben/Differenzen der beiden obigen Modelle für unterschiedliche Bereiche, die in `u_range` spezifiziert werden, z.B. für `u_range=(0,100)` oder `u_range=(-1000, 1000)`?\n",
-        "- Wie lassen sich mögliche Abweichungen erklären?"
+        "### Questions (optional)\n",
+        "- How do the outputs / differences of the two models above behave for different ranges specified in `u_range`, e.g. `u_range=(0,100)` or `u_range=(-1000, 1000)`?\n",
+        "- How can any discrepancies be explained?"
       ]
     },
     {
@@ -1007,7 +1007,7 @@
         "plt.xlabel(\"U [V]\")\n",
         "plt.ylabel(r\"$\\Delta \\hat{I}_{ref}$ [mA]\")\n",
         "plt.legend()\n",
-        "plt.title(f\"Abweichungen diverser ONNX Modelle zur Referenz {first_key}\")\n",
+        "plt.title(f\"Deviations of various ONNX models from the reference {first_key}\")\n",
         "plt.show()"
       ]
     },
@@ -1017,10 +1017,10 @@
         "id": "PBHXjy_NzPci"
       },
       "source": [
-        "### Fragen (Optional)\n",
-        "- Unterscheiden sich die Kurven für INT8/CPU (FP16/CPU) und INT8/GPU (FP16/GPU)? Wieso?\n",
-        "- Wie ist das Verhalten der Kurven für die INT8-Modelle (statisch quantisiert) bei $\\pm 10.0$ zu erklären?\n",
-        "- Gibt es Unterschiede zwischen den statisch und dynamische quantisierten INT8 Modellen?\n"
+        "### Questions (optional)\n",
+        "- Do the curves differ between INT8/CPU (FP16/CPU) and INT8/GPU (FP16/GPU)? Why?\n",
+        "- How can the behavior of the curves for the (statically quantized) INT8 models near $\\pm 10.0$ be explained?\n",
+        "- Are there differences between the statically and dynamically quantized INT8 models?\n"
       ]
     },
     {
@@ -1029,8 +1029,8 @@
         "id": "5F97gmC9waHe"
       },
       "source": [
-        "## Messung der Inferenzzeiten für die quantisierten Modelle\n",
-        "- Wir variieren die Batch-Size und messen die Laufzeit für jeweils $n$ Durchläufe"
+        "## Measuring inference times for the quantized models\n",
+        "- We vary the batch size and measure the runtime for $n$ runs each"
       ]
     },
     {
@@ -1072,7 +1072,7 @@
       "source": [
         "plot_benchmark_results(\n",
         "    results=benchmark_results,\n",
-        "    title=\"Laufzeiten der unterschiedlichen quantisierten Modelle\",\n",
+        "    title=\"Runtimes of the different quantized models\",\n",
         "    xscale=\"log\",\n",
         "    yscale=None,\n",
         ")"
@@ -1084,9 +1084,9 @@
         "id": "E-_5yC16xqIe"
       },
       "source": [
-        "### Fragen (Optional)\n",
-        "- Wie stark ist der Einfluss der Quantisierungen bei diesem Modell auf die Laufzeit?\n",
-        "- Wie ist das Laufzeitverhalten des statisch vs. dynamisch quantisierten Modells?"
+        "### Questions (optional)\n",
+        "- How strongly does quantization affect runtime for this model?\n",
+        "- How does the runtime of the statically vs. dynamically quantized model behave?"
       ]
     },
     {
@@ -1095,18 +1095,18 @@
         "id": "7Fd481-eMB-R"
       },
       "source": [
-        "# 🕸 Teil 3 (Optional): Gotchas bei der Modellquantisierung am Beispiel eines einfachen Modells\n",
+        "# 🕸 Part 3 (optional): Gotchas in model quantization, illustrated with a simple example\n",
         "\n",
-        "In diesem Teil werden wir uns damit befassen, welche Probleme bei der Modellquantisierung auftreten können und dies anhand eines Beispiels illustrieren. Folgende Schritte werden durchgeführt:\n",
-        "- Erstellen eines benutzerdefinierten Modells in Keras zur Mittelwertbildung entlang der Zeitachse.\n",
-        "- Konvertieren des Keras-Modells in das ONNX-Format.\n",
-        "- Quantisieren des ONNX-Modells von FP32 auf FP16.\n",
-        "- Generierung von 3-dimensionalen Zeitreihendaten für die Modellinferenz.\n",
-        "- Modellinferenz mit dem Keras-Modell.\n",
-        "- Modellinferenz mit den FP32/FP16 ONNX-Modellen:\n",
-        "  - Laden und Ausführen von ONNX-Modellen mit der ONNX Runtime.\n",
-        "  - Vergleich der Ausgaben von FP32- und FP16-ONNX-Modellen.\n",
-        "- Diskussion der Beobachtungen und möglicher Lösungen.\n"
+        "In this part we look at the kinds of problems that can arise during model quantization and illustrate them with an example. The following steps are performed:\n",
+        "- Build a custom Keras model that averages along the time axis.\n",
+        "- Convert the Keras model to the ONNX format.\n",
+        "- Quantize the ONNX model from FP32 to FP16.\n",
+        "- Generate 3-dimensional time-series data for model inference.\n",
+        "- Run inference with the Keras model.\n",
+        "- Run inference with the FP32/FP16 ONNX models:\n",
+        "  - Load and execute ONNX models with the ONNX Runtime.\n",
+        "  - Compare the outputs of FP32 and FP16 ONNX models.\n",
+        "- Discuss the observations and possible solutions.\n"
       ]
     },
     {
@@ -1115,7 +1115,7 @@
         "id": "pncih_L8dWVa"
       },
       "source": [
-        "## Modelldefinition"
+        "## Model definition"
       ]
     },
     {
@@ -1124,13 +1124,13 @@
         "id": "Ya6rTWHfamy3"
       },
       "source": [
-        "Unser Modell unten nimmt einen 3-dimensionalen Eingabetensor mit den Dimensionen (Batch-Größe, Sequenzlänge, Merkmalsanzahl) entgegen. In unserem Beispiel hat der Eingabetensor die Form (2, 10000, 3), was bedeutet, dass wir zwei Batch-Elemente haben, jedes mit einer Sequenzlänge von 10000 und 3 Merkmalen pro Zeitschritt.\n",
+        "Our model below takes a 3-dimensional input tensor with shape (batch size, sequence length, number of features). In our example the input tensor has shape (2, 10000, 3), meaning we have two batch elements, each with a sequence length of 10000 and 3 features per time step.\n",
         "\n",
-        "Nach der Verarbeitung durch das Modell wird die Zeitdimension reduziert, und die Ausgabe hat die Form (Batch-Größe, Merkmalsanzahl). Für unser Beispiel ergibt sich eine Ausgabe mit der Form (2, 3). Die Ausgabe repräsentiert den Durchschnitt der Merkmale über die gesamte Sequenzlänge für jedes Batch-Element.\n",
+        "After processing by the model, the time dimension is reduced and the output has shape (batch size, number of features). For our example, this yields an output of shape (2, 3). The output represents the average of the features over the entire sequence length for each batch element.\n",
         "\n",
-        "**Beispiel (Visuelles Beispiel weiter unten)**\n",
+        "**Example (visual example further below)**\n",
         "\n",
-        "Eingabetensor (2 x 4 x 3):\n",
+        "Input tensor (2 x 4 x 3):\n",
         "```\n",
         "[\n",
         "  [\n",
@@ -1148,7 +1148,7 @@
         "]\n",
         "```\n",
         "\n",
-        "Ausgabetensor (2 x 3):\n",
+        "Output tensor (2 x 3):\n",
         "```\n",
         "[\n",
         "  [ 6,  7,  8],\n",
@@ -1240,7 +1240,7 @@
         "id": "eix_OlBl-Nmn"
       },
       "source": [
-        "## Beispiel"
+        "## Example"
       ]
     },
     {
@@ -1278,7 +1278,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Visualisierung der obigen Beispieldaten {display-mode: \"form\"}\n",
+        "# @title Visualize the example data above {display-mode: \"form\"}\n",
         "\n",
         "import matplotlib.pyplot as plt\n",
         "\n",
@@ -1343,7 +1343,7 @@
         "id": "G8_5U6zHgR-_"
       },
       "source": [
-        "## Modellkonvertierung nach ONNX"
+        "## Convert the model to ONNX"
       ]
     },
     {
@@ -1379,7 +1379,7 @@
         "id": "pdLdCuQBgaLi"
       },
       "source": [
-        "## Quantisierung des ONNX Modells"
+        "## Quantize the ONNX model"
       ]
     },
     {
@@ -1428,7 +1428,7 @@
         "id": "6R_B8RE7ggas"
       },
       "source": [
-        "## Datengenerierung"
+        "## Data generation"
       ]
     },
     {
@@ -1508,7 +1508,7 @@
         "id": "HRHQY_j_gzEj"
       },
       "source": [
-        "## Inferenz mit dem Keras Modell"
+        "## Inference with the Keras model"
       ]
     },
     {
@@ -1526,16 +1526,16 @@
         "\n",
         "# Print the dimensions of the input tensor\n",
         "print(\n",
-        "    \"Dimensionen des Eingabetensors:\", str(x_input.shape).replace(\",\", \" x\")\n",
-        ")  # Erwartete Form: (2, 10000, 3)\n",
+        "    \"Input tensor shape:\", str(x_input.shape).replace(\",\", \" x\")\n",
+        ")  # Expected shape: (2, 10000, 3)\n",
         "\n",
         "# Print the dimensions of the Keras model output\n",
         "print(\n",
-        "    \"Dimensionen der Keras-Modellausgabe:\", str(y_output_keras.shape).replace(\",\", \" x\")\n",
+        "    \"Keras model output shape:\", str(y_output_keras.shape).replace(\",\", \" x\")\n",
         ")  # expected shape: (2, 3) -> reduced time axis!\n",
         "\n",
         "# Print the output of the Keras model\n",
-        "print(\"\\nKeras-Modellausgabe:\\n\", y_output_keras)"
+        "print(\"\\nKeras model output:\\n\", y_output_keras)"
       ]
     },
     {
@@ -1544,7 +1544,7 @@
         "id": "tq_N1o4Sg7p9"
       },
       "source": [
-        "## Inferenz mit den FP32/FP16 ONNX Modellen"
+        "## Inference with the FP32/FP16 ONNX models"
       ]
     },
     {
@@ -1585,11 +1585,11 @@
         "id": "hsQD-7RzO2Ao"
       },
       "source": [
-        "## Fragen / Diskussion\n",
-        "- Welche Ergebnisse erwarten wir? Stimmen die Ergebnisse mit den Erwartungen überein?\n",
-        "- Was fällt bei der Ausgabe des quantisierten FP16 Modells auf?\n",
-        "  - Wie könnte man sich dieses Ergebnis erklären?\n",
-        "  - Lässt sich das Problem ggfs. vermeiden?\n"
+        "## Questions / discussion\n",
+        "- What results do we expect? Do the actual results match the expectations?\n",
+        "- What stands out in the output of the quantized FP16 model?\n",
+        "  - How could this result be explained?\n",
+        "  - Can the problem be avoided?\n"
       ]
     },
     {
@@ -1598,7 +1598,7 @@
         "id": "k5i-XeVZVVy7"
       },
       "source": [
-        "# 📞 Teil 4: Quantisierung eines DTMF Klassifikationsmodells"
+        "# 📞 Part 4: Quantizing a DTMF classification model"
       ]
     },
     {
@@ -1616,11 +1616,11 @@
         "id": "UG6JRjlfVVy7"
       },
       "source": [
-        "## Einführung: Generierung und Dekodierung/Klassifizierung von DTMF (dual-tone multi-frequency) Signalen <a class=\"anchor\" id=\"part0\"></a>\n",
+        "## Introduction: Generating and decoding/classifying DTMF (dual-tone multi-frequency) signals <a class=\"anchor\" id=\"part0\"></a>\n",
         "\n",
         "\n",
-        "Das Dualton-Mehrfrequenzwahlverfahren (DTMF) ist ein Signalisierungssystem für das Wählen eines Telefons, das in den frühen 1960er Jahren von Western Electric entwickelt und später von Bell System kommerziell an Telefonkunden geliefert wurde.\n",
-        "Wenn eine Taste auf dem Telefon gedrückt wird, werden zwei harmonische Tonsignale erzeugt, und die Superposition/Überlagerung beider Signale wird verwendet, um die entsprechende Telefontaste zu charakterisieren. Wenn zum Beispiel die Taste „5“ gedrückt wird, entsteht ein Dualtontonsignal, das sich aus den Frequenzen 770 Hz und 1336 Hz zusammensetzt. Die beiden Frequenzen, die jede Taste beschreiben, sind in der folgenden Tabelle aufgeführt:\n",
+        "Dual-tone multi-frequency (DTMF) signaling is a telephone dialing system developed by Western Electric in the early 1960s and later commercially offered to telephone customers by the Bell System.\n",
+        "When a key is pressed on the phone, two harmonic tones are generated, and the superposition of the two signals is used to characterize the corresponding key. When, for example, the \"5\" key is pressed, a dual-tone signal is produced that combines the frequencies 770 Hz and 1336 Hz. The two frequencies for each key are listed in the following table:\n",
         "\n",
         "|   | 1209Hz  | 1336 Hz  | 1477 Hz   | 1633 Hz  |\n",
         "|---|:---:|:---:|:---:|:---:|\n",
@@ -1629,14 +1629,14 @@
         "| **852 Hz**  |  7 | 8  | 9  | C  |\n",
         "| **941 Hz**  |  * | 0  | #  | D  |\n",
         "\n",
-        "In diesem Beispiel werden wir uns ansehen, wie man solche DTMF-Wählsequenzen generiert, sie in einer Audiodatei speichert und das Audiosignal mit einem einfachen KI-Modell wieder dekodiert.\n",
+        "In this example we will look at how to generate such DTMF dial sequences, store them in an audio file, and decode the audio signal again with a simple AI model.\n",
         "\n",
-        "Wir werden die folgenden Schritte durchführen, um ein DTMF-Signal zu erzeugen und mit einem Klassifikationsmodell zu dekodieren:\n",
-        "1. Erzeugung des Signals und der Audiodatei mit `scipy` und `numpy`. Wir speichern die erzeugte Audiodatei in einer `.wav` Datei, die in diesem Notebook oder in deinem lokalen Audioplayer abgespielt werden kann\n",
-        "2. Wir laden eine einfaches KI-Modell, das die Klassifizierung der Tonsignale vornehmen kann\n",
-        "3. Extraktion der gewählten Tastenfolge aus der `.wav`-Datei unter Verwendung des KI-Modells\n",
-        "4. Quantisierung & Export des Modells nach ONNX im FP32 und FP16 Format. Quantisierung nach INT8 und Export nach TensorRT.\n",
-        "5. Laufzeituntersuchungen für FP32/FP16/INT8, unterschiedliche Batch-Größen und Signallängen."
+        "We will go through the following steps to generate a DTMF signal and decode it with a classification model:\n",
+        "1. Generate the signal and audio file with `scipy` and `numpy`. We save the generated audio in a `.wav` file that you can play back in this notebook or in your local audio player.\n",
+        "2. Load a simple AI model that can classify the tone signals.\n",
+        "3. Extract the dialed key sequence from the `.wav` file using the AI model.\n",
+        "4. Quantize & export the model to ONNX in FP32 and FP16 formats. Quantize to INT8 and export to TensorRT.\n",
+        "5. Runtime studies for FP32/FP16/INT8, different batch sizes and signal lengths."
       ]
     },
     {
@@ -1645,9 +1645,9 @@
         "id": "d51a6fcd-760a-4926-8d68-7f75eddb906a"
       },
       "source": [
-        "## Signal- und Audiodatei-Generierung <a class=\"anchor\" id=\"part1\"></a>\n",
-        "- Im folgendem Widget ist es möglich, eine Nummer zu wählen, für die ein DTMF-Signal generiert werden soll\n",
-        "- Falls im Widget keine Nummer \"gewählt\" wird, wird eine Default-Sequenz angenommen"
+        "## Signal and audio-file generation <a class=\"anchor\" id=\"part1\"></a>\n",
+        "- The widget below lets you dial a number for which a DTMF signal should be generated\n",
+        "- If no number is \"dialed\" in the widget, a default sequence is used"
       ]
     },
     {
@@ -1676,7 +1676,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Tastenfeld-Widget für Generierung der Wählsequenz' {display-mode: \"form\"}\n",
+        "# @title Keypad widget for generating the dial sequence {display-mode: \"form\"}\n",
         "\n",
         "from datetime import datetime\n",
         "\n",
@@ -1689,7 +1689,7 @@
         "# Initialize a text widget to display the dial sequence\n",
         "dial_sequence = widgets.Text(\n",
         "    value=\"\",\n",
-        "    placeholder=\"Hier wird die gewählte Nummer stehen\",\n",
+        "    placeholder=\"The dialed number will appear here\",\n",
         "    description=\"\",\n",
         "    disabled=True,\n",
         "    layout=widgets.Layout(width=\"300px\"),\n",
@@ -1870,7 +1870,7 @@
       },
       "outputs": [],
       "source": [
-        "print(\"Gewählte Sequenz:\", dial_sequence.value)"
+        "print(\"Dialed sequence:\", dial_sequence.value)"
       ]
     },
     {
@@ -1879,8 +1879,8 @@
         "id": "D8i2MsZF3o0g"
       },
       "source": [
-        "### Alternativ: Manuelle Generierung des Wähl-Audiosignals\n",
-        "- Dieser Abschnitt kann einfach übersprüngen werden, sollte bereits ein Signal mit dem oberen Widget erzeugt worden sein"
+        "### Alternative: Generate the dial audio signal manually\n",
+        "- This section can be skipped if you already generated a signal with the widget above"
       ]
     },
     {
@@ -1957,7 +1957,7 @@
         "id": "y-9x6ncx3wiD"
       },
       "source": [
-        "### Visualisierung des Wähltonsignals"
+        "### Visualize the dial-tone signal"
       ]
     },
     {
@@ -1974,7 +1974,7 @@
         "plt.plot(my_dialed_sequence_signal)\n",
         "plt.xlabel(\"Index\")\n",
         "plt.ylabel(\"Amplitude\")\n",
-        "plt.title(\"Das vollständige gewählte Signal\")\n",
+        "plt.title(\"The full dialed signal\")\n",
         "plt.show()"
       ]
     },
@@ -1990,7 +1990,7 @@
         "plt.plot(my_dialed_sequence_signal[: 10**4])\n",
         "plt.xlabel(\"Index\")\n",
         "plt.ylabel(\"Amplitude\")\n",
-        "plt.title(\"Die ersten 10000 Datenpunkte des gewählten Signals\")\n",
+        "plt.title(\"The first 10000 data points of the dialed signal\")\n",
         "plt.show()"
       ]
     },
@@ -2008,7 +2008,7 @@
         "plt.plot(my_dialed_sequence_signal)\n",
         "plt.xlabel(\"Index\")\n",
         "plt.ylabel(\"Amplitude\")\n",
-        "plt.title(\"Weiterer Zoom-In\")\n",
+        "plt.title(\"Further zoom-in\")\n",
         "plt.xlim(start_index, start_index + 1.5 * 10**3)\n",
         "plt.show()"
       ]
@@ -2021,9 +2021,9 @@
       },
       "outputs": [],
       "source": [
-        "print(\"Gewählte Sequenz: \", my_dialed_sequence_keys)\n",
-        "print(\"Anzahl verwendeter Zeichen: \", len(set(my_dialed_sequence_keys)))\n",
-        "print(\"Gesamtlänge des Signals:\", my_dialed_sequence_signal.shape[0])"
+        "print(\"Dialed sequence: \", my_dialed_sequence_keys)\n",
+        "print(\"Number of distinct symbols used: \", len(set(my_dialed_sequence_keys)))\n",
+        "print(\"Total signal length:\", my_dialed_sequence_signal.shape[0])"
       ]
     },
     {
@@ -2032,7 +2032,7 @@
         "id": "b763fef4-360e-4a01-910b-add573007fd3"
       },
       "source": [
-        "### Signal-Spektrogramm"
+        "### Signal spectrogram"
       ]
     },
     {
@@ -2050,7 +2050,7 @@
         "plt.ylim(0, 3000)\n",
         "plt.xlabel(\"t [s]\")\n",
         "plt.ylabel(\"f [Hz]\")\n",
-        "plt.title(\"Spektrogramm des generierten Telefonwählsignals\")\n",
+        "plt.title(\"Spectrogram of the generated phone dial signal\")\n",
         "plt.show(im)"
       ]
     },
@@ -2060,10 +2060,10 @@
         "id": "Aio7fvyo4ZUy"
       },
       "source": [
-        "## Konvertierung des vortrainierten Keras Modells\n",
+        "## Convert the pre-trained Keras model\n",
         "\n",
-        "Optionale Fragen:\n",
-        "- Wie könnte man mit einem klassischen Ansatz oder auch mit einem neuronalem Netz die Wählsequenz extrahieren?"
+        "Optional questions:\n",
+        "- How could you extract the dial sequence using either a classical approach or a neural network?"
       ]
     },
     {
@@ -2072,20 +2072,20 @@
         "id": "YtHys5X74cRB"
       },
       "source": [
-        "### Laden des vortrainierten Keras Modells\n",
+        "### Load the pre-trained Keras model\n",
         "\n",
-        "- Wir verwenden ein vortrainiertes Netz um uns die Trainingszeit zu ersparen\n",
-        "- Das Training kann weiter unten reproduziert werden\n",
-        "- Modellarchitektur:\n",
-        "  - Im Wesentlichen ein sogenenanntes Conv-Net (Fully Convolutional Net, FCN)\n",
-        "  - Einige Downsampling layer (MaxPooling) und Upsampling layer\n",
-        "  - Input: Ein Batch mit der Dimension N x T x 1, wobei N die Batch-Größe und T die Länge der Signale darstellt.\n",
-        "  - Output: N x T x 17, wobei wir nun 16+1=17 Ausgabesignale haben, ein Signal pro Taste (0,1,2,...,*,#,A,B,C,D) und 1 Signal für \"keine Taste aktiv\"\n",
-        "  - Output-Schicht: \"Softmax\" layer. Bedeutet, dass jedes Element in einem 17-dim. Vektor eine Wahrscheinlichkeit darstellt und dass die Summe über jeden 17-dim. Vektor genau 1 ergibt.\n",
+        "- We use a pre-trained network to save training time\n",
+        "- The training can be reproduced further below\n",
+        "- Model architecture:\n",
+        "  - Essentially a so-called ConvNet (fully convolutional network, FCN)\n",
+        "  - Several downsampling layers (MaxPooling) and upsampling layers\n",
+        "  - Input: a batch with shape N x T x 1, where N is the batch size and T the signal length.\n",
+        "  - Output: N x T x 17, where we now have 16+1=17 output signals — one signal per key (0,1,2,...,*,#,A,B,C,D) and 1 signal for \"no key active\"\n",
+        "  - Output layer: a \"softmax\" layer. This means each element of a 17-dim vector represents a probability, and the sum over each 17-dim vector is exactly 1.\n",
         "\n",
         "\n",
-        "Optionale Fragen:\n",
-        "- Gibt es andere/elegantere Möglichkeiten um insbesondere ein brauchbares Output zu erzeugen (anstatt eines N x T x 17 Signals)?"
+        "Optional questions:\n",
+        "- Are there other / more elegant ways to produce a usable output (instead of an N x T x 17 signal)?"
       ]
     },
     {
@@ -2145,7 +2145,7 @@
         ")\n",
         "end = time.time()\n",
         "\n",
-        "print(\"Inferenzzeit:\", round(end - start, 2), \"Sekunden\")\n",
+        "print(\"Inference time:\", round(end - start, 2), \"seconds\")\n",
         "\n",
         "cmap = plt.get_cmap(\"tab20\")\n",
         "\n",
@@ -2164,9 +2164,9 @@
         "    loc=\"upper center\",\n",
         "    bbox_to_anchor=(0.5, -0.15),\n",
         "    ncol=8,\n",
-        "    title=\"Prognostizierte Tasten\",\n",
+        "    title=\"Predicted keys\",\n",
         ")\n",
-        "plt.title(f\"Tatsächliche Wählsequenz: {' '.join(list(my_dialed_sequence_keys))}\")\n",
+        "plt.title(f\"Actual dial sequence: {' '.join(list(my_dialed_sequence_keys))}\")\n",
         "plt.show()"
       ]
     },
@@ -2179,10 +2179,10 @@
       "outputs": [],
       "source": [
         "predicted_key_sequence = dtmf_gen.decode_prediction(keras_pred)\n",
-        "print(\"Prognostizierte Wählsequenz:\", predicted_key_sequence)\n",
+        "print(\"Predicted dial sequence:\", predicted_key_sequence)\n",
         "print(\n",
-        "    \"Passt die Prognose zur tatsächlich gewählten Sequenz?:\",\n",
-        "    \"Ja!\" if predicted_key_sequence == my_dialed_sequence_keys else \"Nein!\",\n",
+        "    \"Does the prediction match the actual dialed sequence?:\",\n",
+        "    \"Yes!\" if predicted_key_sequence == my_dialed_sequence_keys else \"No!\",\n",
         ")"
       ]
     },
@@ -2192,7 +2192,7 @@
         "id": "-97qYaeo4k86"
       },
       "source": [
-        "### Konvertierung des Keras Modells nach ONNX"
+        "### Convert the Keras model to ONNX"
       ]
     },
     {
@@ -2230,7 +2230,7 @@
         "id": "y-CLAhtx4tTw"
       },
       "source": [
-        "### Optimierung des ONNX Modells"
+        "### Optimize the ONNX model"
       ]
     },
     {
@@ -2285,7 +2285,7 @@
         "id": "W0s4ULT84ynC"
       },
       "source": [
-        "### FP16 Quantisierung des ONNX Modells"
+        "### FP16 quantization of the ONNX model"
       ]
     },
     {
@@ -2319,11 +2319,11 @@
         "id": "8-Q48XtarK-2"
       },
       "source": [
-        "### INT8 Quantisierung des ONNX Modells\n",
-        "- dynamische INT8 Quantisierung derzeit nicht möglich, da die ONNX Runtime dynamisch-quantisierte Conv1D Layer aktuell nicht unterstützt\n",
-        "- statische INT8 Quantisierung in ONNX funktioniert, jedoch sind keine Laufzeitvorteile in der ONNX Runtime gegenüber des FP32 Modells erkennbar (Code in Anhang)\n",
-        "- Auch keine Laufzeitverbesserung mit QAT in TensorFlow und Export nach INT8 ONNX Modell (Code in Anhang)\n",
-        "- **Daher**: Verwendung von INT8 Quantisierung in Nvidia TensorRT"
+        "### INT8 quantization of the ONNX model\n",
+        "- dynamic INT8 quantization is not currently possible because the ONNX Runtime does not yet support dynamically quantized Conv1D layers\n",
+        "- static INT8 quantization in ONNX works, but no runtime benefit over the FP32 model is observed in the ONNX Runtime (code in the appendix)\n",
+        "- no runtime improvement either with QAT in TensorFlow and export to an INT8 ONNX model (code in the appendix)\n",
+        "- **Therefore**: use INT8 quantization in NVIDIA TensorRT"
       ]
     },
     {
@@ -2332,7 +2332,7 @@
         "id": "xIEjIXGXq_k6"
       },
       "source": [
-        "## Modell-Experimente"
+        "## Model experiments"
       ]
     },
     {
@@ -2341,7 +2341,7 @@
         "id": "ajTlV0ndF3j0"
       },
       "source": [
-        "### Laden der einzelnen Modelle für die Inferenz"
+        "### Load the individual models for inference"
       ]
     },
     {
@@ -2396,7 +2396,7 @@
         "id": "dr9fxW_MsMbX"
       },
       "source": [
-        "#### Verwendung eines der quantisierten Modelle für unser generiertes Wähltonsignals"
+        "#### Use one of the quantized models on our generated dial-tone signal"
       ]
     },
     {
@@ -2414,8 +2414,8 @@
         "predicted_key_sequence = dtmf_gen.decode_prediction(onnx_prediction)\n",
         "print(\"Predicted Sequence:\", predicted_key_sequence)\n",
         "print(\n",
-        "    \"Passt die Prognose zur tatsächlichen gewählten Sequenz?:\",\n",
-        "    \"Ja!\" if predicted_key_sequence == my_dialed_sequence_keys else \"Nein!\",\n",
+        "    \"Does the prediction match the actual dialed sequence?:\",\n",
+        "    \"Yes!\" if predicted_key_sequence == my_dialed_sequence_keys else \"No!\",\n",
         ")"
       ]
     },
@@ -2425,16 +2425,16 @@
         "id": "Ns8srDuD5Ji1"
       },
       "source": [
-        "### Laufzeitmessung (Latenz) der individuellen Modelle\n",
-        "- Messung der Inferenzzeiten für 4 Modelle:\n",
-        "  - Keras, FP32 (ursprüngliches Modell)\n",
+        "### Runtime measurement (latency) of the individual models\n",
+        "- Measure inference times for 4 models:\n",
+        "  - Keras, FP32 (original model)\n",
         "  - ONNX, FP32\n",
         "  - ONNX, FP16\n",
         "  - TensorRT, INT8\n",
-        "- Verschiedene Batch-Größen: 1,2,4,...,\n",
-        "- Signallänge: 4096\n",
-        "- \"Aufwärmen\" der Modelle: Jeweils 20 Durchläufe für eine Batch-Größe\n",
-        "- 100-fache Wiederholung jeder Messung"
+        "- Different batch sizes: 1, 2, 4, ...\n",
+        "- Signal length: 4096\n",
+        "- \"Warm up\" the models: 20 runs per batch size\n",
+        "- Each measurement is repeated 100 times"
       ]
     },
     {
@@ -2467,7 +2467,7 @@
         "    n_runs=n_runs,\n",
         "    n_warmup=n_warmup,\n",
         ")\n",
-        "print(f\"Benchmark beendet nach {time.time() - start: .2f} Sekunden\")"
+        "print(f\"Benchmark finished after {time.time() - start: .2f} seconds\")"
       ]
     },
     {
@@ -2487,7 +2487,7 @@
         "\n",
         "plot_benchmark_results(\n",
         "    results={k: v for k, v in dtmf_benchmark_results.items() if k in show_models},\n",
-        "    title=\"Inferenzzeiten von DTMF-Klassifikationsmodellen\",\n",
+        "    title=\"Inference times of DTMF classification models\",\n",
         "    xscale=\"log\",\n",
         "    yscale=None,\n",
         ")"
@@ -2508,8 +2508,8 @@
         "df_runtimes = pd.DataFrame({\n",
         "    k: v.median(axis=0) * 1000.0 for k, v in dtmf_benchmark_results.items()\n",
         "})\n",
-        "df_runtimes.index.name = \"Batchgröße\"\n",
-        "display(widgets.HTML(\"<h2>Durchschnittliche Inferenzzeiten in Millisekunden</h2>\"))\n",
+        "df_runtimes.index.name = \"Batch size\"\n",
+        "display(widgets.HTML(\"<h2>Average inference times in milliseconds</h2>\"))\n",
         "display(df_runtimes)"
       ]
     },
@@ -2521,7 +2521,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Speedup der quantisierten Modelle ggü. Keras-Modell {display-mode: \"form\"}\n",
+        "# @title Speedup of the quantized models vs. the Keras model {display-mode: \"form\"}\n",
         "from techdays25.plotting_utils import plot_speedup\n",
         "\n",
         "plot_speedup(df_runtimes, reference_model=\"keras (FP32)\", batch_size=512)"
@@ -2533,7 +2533,7 @@
         "id": "CFZx9ylH06K2"
       },
       "source": [
-        "## Genauigkeit der (quantisierten) Modelle"
+        "## Accuracy of the (quantized) models"
       ]
     },
     {
@@ -2582,7 +2582,7 @@
       },
       "outputs": [],
       "source": [
-        "# @title Genauigkeit der einzelnen Modelle für unterschiedliches Rauschverhalten auswerten {display-mode: \"form\"}\n",
+        "# @title Evaluate accuracy of each model under different noise conditions {display-mode: \"form\"}\n",
         "\n",
         "import Levenshtein\n",
         "import matplotlib.pyplot as plt\n",
@@ -2595,7 +2595,7 @@
         "def plot_acc_metrics(df_levenshtein, df_accuracies, avg_sequence_length):\n",
         "    def plot(which_result):\n",
         "        df = df_levenshtein if which_result == \"levenshtein\" else df_accuracies\n",
-        "        df.index.name = \"Rauschlevel\"\n",
+        "        df.index.name = \"Noise level\"\n",
         "        cmap = plt.get_cmap(\"tab10\")\n",
         "        colors = [cmap(i) for i in range(len(df.columns))]\n",
         "\n",
@@ -2603,12 +2603,12 @@
         "        for column, color in zip(df.columns, colors):\n",
         "            plt.plot(df[column], color=color, label=column)\n",
         "\n",
-        "        plt.xlabel(\"Rauschlevel\")\n",
+        "        plt.xlabel(\"Noise level\")\n",
         "        plt.ylabel(which_result)\n",
         "        plt.legend()\n",
         "        plt.grid()\n",
         "        plt.title(\n",
-        "            f\"Metrik '{which_result}' für ausgewählte Modelle (mittlere Sequenzlänge: {avg_sequence_length: .2f})\"\n",
+        "            f\"Metric '{which_result}' for selected models (average sequence length: {avg_sequence_length: .2f})\"\n",
         "        )\n",
         "        plt.show()\n",
         "\n",
@@ -2646,7 +2646,7 @@
         "noise_level_accuracies = {}\n",
         "noise_level_levenshtein = {}\n",
         "\n",
-        "print(\"Auswertung läuft \", end=\"\")\n",
+        "print(\"Evaluation running \", end=\"\")\n",
         "for noise_level in noise_levels:\n",
         "    X_val, Y_val = dtmf_gen.generate_dataset(\n",
         "        n_samples=batch_size, t_length=signal_length, noise_factor=noise_level\n",
@@ -2695,9 +2695,9 @@
         "id": "bN2XVzIyy_Ww"
       },
       "source": [
-        "## Anhang 1: Reproduktion/Erneutes Training des Keras DTMF Klassifikationsmodells (Optional)\n",
+        "## Appendix 1: Reproducing / retraining the Keras DTMF classification model (optional)\n",
         "\n",
-        "**Hinweis:** Da das Training des Modells vergleichsweise viele Ressourcen benötigt (RAM/GPU), sollte *jetzt* die Colab Sitzung neugestartet werden!"
+        "**Note:** Training the model requires comparatively many resources (RAM/GPU), so you should *now* restart the Colab session!"
       ]
     },
     {
@@ -2854,7 +2854,7 @@
         "id": "XeF16bolNFX1"
       },
       "source": [
-        "# Anhang 2: Analyse eines kleinen DTMF Klassifikationsmodells im Frequenzbereich"
+        "# Appendix 2: Analysis of a small DTMF classification model in the frequency domain"
       ]
     },
     {
@@ -3029,8 +3029,8 @@
         "    layer = find_layer_by_name(loaded_model, layer_name=layer_name)\n",
         "\n",
         "    # Print the name and weights of the n-th layer\n",
-        "    # print(f\"Name der {n + 1}. Schicht (Index {n}): {layer_name}\")\n",
-        "    # print(f\"Gewichte der {n+1}. Schicht (Index {n}):\\n\", weights)\n",
+        "    # print(f\"Name of the {n + 1}-th layer (index {n}): {layer_name}\")\n",
+        "    # print(f\"Weights of the {n+1}-th layer (index {n}):\\n\", weights)\n",
         "\n",
         "    weights = layer.get_weights()\n",
         "\n",
@@ -3067,7 +3067,7 @@
         "    ax1 = fig.add_subplot(521 + idx)\n",
         "\n",
         "    # ax1.set_title(\"Dilation rate q=\" + str(dil_rate))\n",
-        "    ax1.set_title(f\"Frequenzantwort für Schicht {layer_name}\")\n",
+        "    ax1.set_title(f\"Frequency response for layer {layer_name}\")\n",
         "\n",
         "    if amp_in_db:\n",
         "        plt.plot(w, 20 * np.log10(abs(h)), \"b\")\n",
@@ -3303,7 +3303,7 @@
         "id": "v9SuALdPYq5N"
       },
       "source": [
-        "## Trainingsprozess für das einfache obige Modell für die Analyse im Frequenzraum"
+        "## Training process for the simple model above for analysis in the frequency domain"
       ]
     },
     {
@@ -3475,7 +3475,7 @@
         "id": "5W5cGlTk9FgG"
       },
       "source": [
-        "# Anhang 3: Experimente mit \"Quantization Aware Training\" in TensorFlow"
+        "# Appendix 3: Experiments with \"Quantization Aware Training\" in TensorFlow"
       ]
     },
     {
@@ -3690,7 +3690,7 @@
         "id": "h2g33IROY5vX"
       },
       "source": [
-        "# Anhang 4: ONNX INT8 Quantizatisierung vom DTMF-Klassifizierungsmodells"
+        "# Appendix 4: ONNX INT8 quantization of the DTMF classification model"
       ]
     },
     {


### PR DESCRIPTION
Translate all German markdown cells, code comments, plot titles, @title cell-form headers, and interactive-widget labels in lab2-model-quantization.ipynb to English. Notebook JSON formatting and cell IDs are preserved; cell outputs are left as-is and will be refreshed on the next Colab run.

Pre-commit is bypassed for this commit because the file has 25 pre-existing ruff lint errors (D103, N802, N803, A004) unrelated to translation. These will be addressed in a follow-up cleanup PR.