### PR TITLE
fix: translate lab3 outline cells to English

### DIFF
--- a/notebooks/lab3-introduction-to-tensorrt.ipynb
+++ b/notebooks/lab3-introduction-to-tensorrt.ipynb
@@ -16,7 +16,7 @@
         "id": "T4TgMJt1Gp4-"
       },
       "source": [
-        "# 🚀 Lab 3: Erste Schritte mit TensorRT"
+        "# 🚀 Lab 3: First Steps with TensorRT"
       ]
     },
     {
@@ -25,25 +25,25 @@
         "id": "cDvwfntVHHfV"
       },
       "source": [
-        "## Struktur\n",
-        "- Teil 1:\n",
-        "  - Mit einfachem Beispiel aus Lab1 (Lineares Modell) beginnen\n",
-        "  - Konvertierung nach TensorRT mit der Python SDK\n",
-        "  - Miniminal Working Example um eine TensorRT Engine zu starten und eine einfache Inferenz durchzuführen\n",
-        "- Verwendung eines vortrainierten DL-Modells das Vier Gewinnt spielen kann (trainiert mit TD($\\lambda$)-Learning)\n",
-        "  - Modell ist klein genug für Google Colab\n",
-        "- Konvertierung von PyTorch->ONNX->TensorRT (trtexec & Python SDK)\n",
-        "- Messung der Inferenzzeiten für PT, ONNX (FP32, FP16), TensorRT (FP32, FP16).\n",
-        "- Laufzeit in Abhängigkeit der Batch Size\n",
-        "- TensorRT-spezifische Verbesserungen\n",
-        "  - Einfluss des Pinned Memory\n",
-        "  - Asynchrone Inference mit `enqueue()` anstatt `execute()`\n",
-        "  - Optimierungsprofile\n",
+        "## Outline\n",
+        "- Part 1:\n",
+        "  - Start with a simple example from Lab 1 (linear model)\n",
+        "  - Convert to TensorRT using the Python SDK\n",
+        "  - Minimal working example to launch a TensorRT engine and run a simple inference\n",
+        "- Use a pre-trained DL model that can play Connect Four (trained with TD($\\lambda$) learning)\n",
+        "  - The model is small enough for Google Colab\n",
+        "- Conversion from PyTorch -> ONNX -> TensorRT (trtexec & Python SDK)\n",
+        "- Measure inference times for PT, ONNX (FP32, FP16), TensorRT (FP32, FP16).\n",
+        "- Runtime as a function of batch size\n",
+        "- TensorRT-specific improvements\n",
+        "  - Effect of pinned memory\n",
+        "  - Asynchronous inference using `enqueue()` instead of `execute()`\n",
+        "  - Optimization profiles\n",
         "- Profiling:\n",
         "  - trtexec\n",
-        "  - advanced profiling with NVIDIA Nsight toolset\n",
-        "- Optional. Weitere Optimierungen:\n",
-        "  - Sparsity: Der Feature-Vector ist sehr dünn besetzt. Optimierung unter Verwendung von \"sparse\" Operationen (sparse dot product)\n"
+        "  - Advanced profiling with the NVIDIA Nsight toolset\n",
+        "- Optional. Further optimizations:\n",
+        "  - Sparsity: the feature vector is very sparse. Optimization using \"sparse\" operations (sparse dot product)\n"
       ]
     },
     {


### PR DESCRIPTION
Translate the title and outline markdown cells in
lab3-introduction-to-tensorrt.ipynb from German to English. Notebook JSON formatting and cell IDs are preserved.